### PR TITLE
Sl fifo test

### DIFF
--- a/python_client/ambu_control.py
+++ b/python_client/ambu_control.py
@@ -206,6 +206,7 @@ class AmbuControl(object):
     def stop(self):
         self._runEn = False
         self._thread.join()
+        self._qmgr.join()
 
     def start(self):
         self._runEn = True
@@ -276,9 +277,12 @@ class AmbuControl(object):
 
     def _queueMgrThread(self):
         while self._runEn:
-            (data, count, rate, stime, artime, volMax, pipMax) = self._queue.get(block=True)
-            self._dataCallBack(data, count, rate, stime, artime, volMax, pipMax)
-
+            try:
+                # need to block with timeout - otherwise wait is uninterruptible on Windows
+                (data, count, rate, stime, artime, volMax, pipMax) = self._queue.get(block=True,timeout=1)
+                self._dataCallBack(data, count, rate, stime, artime, volMax, pipMax)
+            except:
+                pass
 
     def _handleSerial(self):
         counter=0

--- a/python_client/ambu_control.py
+++ b/python_client/ambu_control.py
@@ -276,12 +276,8 @@ class AmbuControl(object):
 
     def _queueMgrThread(self):
         while True:
-            (self._data, count, rate, stime, artime, volMax, pipMax) = self._queue.get(block=True)
-            self._dataCallBack(self._data, count, rate, stime, artime, volMax, pipMax)
-
-    
-
-        
+            (data, count, rate, stime, artime, volMax, pipMax) = self._queue.get(block=True)
+            self._dataCallBack(data, count, rate, stime, artime, volMax, pipMax)
 
 
     def _handleSerial(self):

--- a/python_client/ambu_control.py
+++ b/python_client/ambu_control.py
@@ -28,8 +28,6 @@ class AmbuControl(object):
 
         self._ser = None #serial.Serial(port=dev, baudrate=57600, timeout=1.0)
         self._queue = queue.Queue(3)
-        self._qmgr = threading.Thread(target=self._queueMgrThread)
-        self._qmgr.start()
         self._runEn = False
         self._dataCallBack  = self._debugCallBack
         self._stateCallBack = None
@@ -211,6 +209,8 @@ class AmbuControl(object):
 
     def start(self):
         self._runEn = True
+        self._qmgr = threading.Thread(target=self._queueMgrThread)
+        self._qmgr.start()
         self._thread = threading.Thread(target=self._handleSerial)
         self._thread.start()
         self.requestConfig()
@@ -275,7 +275,7 @@ class AmbuControl(object):
 
 
     def _queueMgrThread(self):
-        while True:
+        while self._runEn:
             (data, count, rate, stime, artime, volMax, pipMax) = self._queue.get(block=True)
             self._dataCallBack(data, count, rate, stime, artime, volMax, pipMax)
 
@@ -390,8 +390,6 @@ class AmbuControl(object):
                 #traceback.print_exc()
                 #print(f"Got handleSerial error {e}")
                 pass
-
-
 
 
 


### PR DESCRIPTION
The serial receiving thread cannot tolerate delays in the main loop, otherwise receiving falls behind and old data may get queued up and displayed late. This can happen because the 'new data' callback to the display can take time to return on slow computers.

To prevent this without having to rewrite the complete serial device handling, this pull request introduces a shallow FIFO between the serial thread and the data update callback managed by a separate thread. Instead of calling the callback directly, updates are either atomically written to the FIFO or dropped without ever blocking; this guarantees that the serial thread never gets delayed.

The FIFO gets drained asynchronously by its management thread into the update callback.

Currently the depth of the FIFO is set to 3, while somewhat arbitrary this limits the number of updates than can be queued. 

The management thread is started and stopped the same way as the Serial handler thread. 



